### PR TITLE
Fix conda environment.yaml

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -79,7 +79,6 @@ dependencies:
       - click==8.0.4
       - compressai==1.2.4
       - cycler==0.11.0
-      - dct-manip==0.2.3
       - decorator==4.4.2
       - defusedxml==0.7.1
       - docker-pycreds==0.4.0


### PR DESCRIPTION
- Fix the filename: `enviroment.yaml → environment.yaml`

- Remove invalid "dct-manip" dependency which does not exist and must be installed manually *after* creating the Conda environment.