### PR TITLE
Installation and Testing Improvements

### DIFF
--- a/models/JDEC.py
+++ b/models/JDEC.py
@@ -9,7 +9,7 @@ from utils_ import make_coord
 import numpy as np 
 
 
-@register('jdec')
+@register('IPEC-decoder_dctform-rgb-share-size4')
 class JDEC(nn.Module):
     def __init__(self, encoder_spec,decoder_spec=None , hidden_dim=256):
         super().__init__()  

--- a/test.py
+++ b/test.py
@@ -7,7 +7,6 @@ import torch
 
 from torchvision import transforms
 import numpy as np
-import models
 
 from tqdm import tqdm
 from utils_ import Averager
@@ -17,6 +16,7 @@ import utils.custom_transforms as ctrans
 import dct_manip as dm
 from utils_ import mkdir
 import utils_
+from models.models import models, make
 
 
 
@@ -32,7 +32,9 @@ elif setname is 'ICB':
 model_path = './PATH_TO_MODEL'
 
 model_spec = torch.load(model_path)['model']
-model = models.make(model_spec, load_sd=True).cuda()
+print("Available models:", models.keys())
+model_spec['args']['encoder_spec']['name'] = 'swinv2_group_embedded'
+model = make(model_spec, load_sd=True).cuda()
 
 batch_y = Rearrange('c (h s1) (w s2) ph pw -> (h w) c s1 s2 ph pw',s1 = 140, s2=140)
 batch_c = Rearrange('c (h s1) (w s2) ph pw -> (h w) c s1 s2 ph pw',s1 = 70, s2=70)


### PR DESCRIPTION
## Issues Found
1. Model Registration Mismatches
   - Architecture name mismatch in checkpoint: expected 'IPEC-decoder_dctform-rgb-share-size4'
   - Required adding correct registration decorator in JDEC.py:
     ```python
     @register('IPEC-decoder_dctform-rgb-share-size4')  # Changed from 'jdec'
     class JDEC(nn.Module):
     ```
   - Secondary mismatch with 'swinv2_rgb_nomore_deepir_rgbver' encoder model
   - Quick fix implemented by using existing 'swinv2_group_embedded' architecture which shares the same underlying structure

2. Environment Setup Issues
   - Missing directory structure for temporary files
   - Added missing `bin` directory creation for JPEG processing through gitkeep

## Testing Performed

Tested on Ubuntu 20.04 environment
Successfully processed test images
